### PR TITLE
Zero-initialize memory in FFT

### DIFF
--- a/code/FFT_new.cpp
+++ b/code/FFT_new.cpp
@@ -5,7 +5,7 @@
 struct cpx
 {
   cpx(){}
-  cpx(double aa):a(aa){}
+  cpx(double aa):a(aa),b(0){}
   cpx(double aa, double bb):a(aa),b(bb){}
   double a;
   double b;


### PR DESCRIPTION
Using std::complex would be better, but in the mean time, this makes the division by 8 in main do the right thing.
