### PR TITLE
Fix bug in LongestIncreasingSubsequence

### DIFF
--- a/code/LongestIncreasingSubsequence.cc
+++ b/code/LongestIncreasingSubsequence.cc
@@ -1,4 +1,4 @@
-// Given a list of numbers of length n, this routine extracts a 
+// Given a list of numbers of length n, this routine extracts a
 // longest increasing subsequence.
 //
 // Running time: O(n log n)
@@ -21,7 +21,7 @@ typedef vector<PII> VPII;
 VI LongestIncreasingSubsequence(VI v) {
   VPII best;
   VI dad(v.size(), -1);
-  
+
   for (int i = 0; i < v.size(); i++) {
 #ifdef STRICTLY_INCREASNG
     PII item = make_pair(v[i], 0);
@@ -35,11 +35,11 @@ VI LongestIncreasingSubsequence(VI v) {
       dad[i] = (best.size() == 0 ? -1 : best.back().second);
       best.push_back(item);
     } else {
-      dad[i] = dad[it->second];
+      dad[i] = it == best.begin() ? -1 : prev(it)->second;
       *it = item;
     }
   }
-  
+
   VI ret;
   for (int i = best.back().second; i >= 0; i = dad[i])
     ret.push_back(v[i]);


### PR DESCRIPTION
The `dad` array was not being updated properly.
E.g., running LongestIncreasingSubsequence on {5,6,2,3} would return {5,3}.

Fixes #8