### PR TITLE
Misleading title

### DIFF
--- a/97si_slides/comp_geometry.tex
+++ b/97si_slides/comp_geometry.tex
@@ -43,7 +43,7 @@
 
 %% begin presentation
 
-\title{\large \bfseries Shortest Path Algorithms}
+\title{\large \bfseries Computational Geometry}
 
 \author{Jaehyun Park\\[3ex]
 CS 97SI\\


### PR DESCRIPTION
changed title to computational geometry instead of shortest path algorithms.