### PR TITLE
Ordered solutions for ax = b (mod n)

### DIFF
--- a/code/Euclid.cc
+++ b/code/Euclid.cc
@@ -53,13 +53,13 @@ int extended_euclid(int a, int b, int &x, int &y) {
 	return a;
 }
 
-// finds all solutions to ax = b (mod n)
+// finds all solutions to ax = b (mod n) in ascending order
 VI modular_linear_equation_solver(int a, int b, int n) {
 	int x, y;
 	VI ret;
 	int g = extended_euclid(a, n, x, y);
 	if (!(b%g)) {
-		x = mod(x*(b / g), n);
+		x = mod(mod(x*(b / g), n), n / g);
 		for (int i = 0; i < g; i++)
 			ret.push_back(mod(x + i*(n / g), n));
 	}


### PR DESCRIPTION
Generating the solutions for ax = b (mod n) in ascending order can be done without sorting the vector.

The modification works since every two consecutive solutions have distance equal to `n / g`. This way, a valid solution `x` modulo `n / g` will always get the smallest solution.

Moreover, with this change way it is also easier to adapt the code to obtain the k-th smallest solution.

Some test cases:
```
a=84560 b=13419 c=13577
previous output: 9957
new output:      9957

a=37090 b=27028 n=49262
previous output: 8084 32715
new output:      8084 32715

a=50954 b=22474 n=28494
previous output: 14843 596
new output:      596 14843

a=72399 b=17997 n=20292
previous output: 12399 19163 5635
new output:      5635 12399 19163

a=12129 b=31449 n=42840
previous output: 42281 13721 28001
new output:      13721 28001 42281

a=16480 b=35244 n=41924
previous output: 32740 1297 11778 22259
new output:      1297 11778 22259 32740
```